### PR TITLE
Update readme for EOL config issue (Closes #32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ If you added `"files.associations": {"*.svelte": "html" }` to your CoC settings,
 
 Do you want to use TypeScript/SCSS/Less/..? [See the docs](/docs/README.md#language-specific-setup).
 
+To ensure you get correct line endings when auto importing/organizing imports, set the following line in your CoC settings: `"svelte.files.eol": "EOL"`, where EOL is either `\n` (unix line endings), or `\r\n` (for carriage return line endings).
+
 ## Features
 
 -   Svelte


### PR DESCRIPTION
Was having an issue where auto-imports and organize imports were leaving `^M` characters at the end of the lines they changed, and tried to dig through the plugin/language server to see why it wasn't getting set properly.

Adding the one line I've added in the README fixes the issue - I assume that the svelte language server pulls from this workspace configuration setting implicitly.