### PR TITLE
Handle document changes in .js and .ts files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -111,7 +111,7 @@ export function activate(context: ExtensionContext) {
         return ls;
     }
 
-    addDidChangeTextDocumentListener(getLS);
+    context.subscriptions.push(addDidChangeTextDocumentListener(getLS));
 
     TsPlugin.create(context);
 }
@@ -120,7 +120,7 @@ function addDidChangeTextDocumentListener(getLS: () => LanguageClient) {
     // Only Svelte file changes are automatically notified through the inbuilt LSP
     // because the extension says it's only responsible for Svelte files.
     // Therefore we need to set this up for TS/JS files manually.
-    workspace.onDidChangeTextDocument((evt) => {
+    return workspace.onDidChangeTextDocument((evt) => {
         if (evt.textDocument.uri.endsWith('.ts') || evt.textDocument.uri.endsWith('.js')) {
             getLS().sendNotification('$/onDidChangeTsOrJsFile', {
                 uri: evt.textDocument.uri,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -106,7 +106,34 @@ export function activate(context: ExtensionContext) {
             window.showMessage('Svelte language server restarted.');
         }
     }
+
+    function getLS() {
+        return ls;
+    }
+
+    addDidChangeTextDocumentListener(getLS);
+
     TsPlugin.create(context);
+}
+
+function addDidChangeTextDocumentListener(getLS: () => LanguageClient) {
+    // Only Svelte file changes are automatically notified through the inbuilt LSP
+    // because the extension says it's only responsible for Svelte files.
+    // Therefore we need to set this up for TS/JS files manually.
+    workspace.onDidChangeTextDocument((evt) => {
+        if (evt.textDocument.uri.endsWith('.ts') || evt.textDocument.uri.endsWith('.js')) {
+            getLS().sendNotification('$/onDidChangeTsOrJsFile', {
+                uri: evt.textDocument.uri,
+                changes: evt.contentChanges.map((c) => ({
+                    range: {
+                        start: { line: c.range.start.line, character: c.range.start.character },
+                        end: { line: c.range.end.line, character: c.range.end.character },
+                    },
+                    text: c.text,
+                })),
+            });
+        }
+    });
 }
 
 function createLanguageServer(serverOptions: ServerOptions, clientOptions: LanguageClientOptions) {


### PR DESCRIPTION
The Svelte VSCode extension monitors changes to JS/TS files so that it can manually notify the Svelte language server of those changes. This makes Svelte Typescript support update in real-time for changes in non-Svelte files.

This PR is a copy from the VSCode extension, with a minor change to check the filename instead of using the `document.languageId` field which coc.nvim doesn't provide.

The bulk of the original code is here for comparison: https://github.com/sveltejs/language-tools/blob/a0b01ff7a58e6bedf0bb087b0023d3b6ea7cd0eb/packages/svelte-vscode/src/extension.ts#L275