### PR TITLE
Upstream updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,31 +20,16 @@ Do you want to use TypeScript/SCSS/Less/..? [See the docs](/docs/README.md#langu
 
 ## Features
 
--   Svelte
-    -   Diagnostic messages for warnings and errors
-    -   Support for svelte preprocessors that provide source maps
-    -   Svelte specific formatting (via [prettier-plugin-svelte](https://github.com/sveltejs/prettier-plugin-svelte))
--   HTML
-    -   Hover info
-    -   Autocompletions
-    -   [Emmet](https://emmet.io/)
-    -   Symbols in Outline panel
--   CSS / SCSS / LESS
-    -   Diagnostic messages for syntax and lint errors
-    -   Hover info
-    -   Autocompletions
-    -   Formatting (via [prettier](https://github.com/prettier/prettier))
-    -   [Emmet](https://emmet.io/)
-    -   Color highlighting and color picker
-    -   Symbols in Outline panel
--   TypeScript / JavaScript
-    -   Diagnostics messages for syntax errors, semantic errors, and suggestions
-    -   Hover info
-    -   Formatting (via [prettier](https://github.com/prettier/prettier))
-    -   Symbols in Outline panel
-    -   Autocompletions
-    -   Go to definition
-    -   Code Actions
+You can expect the following within Svelte files:
+
+-   Diagnostic messages
+-   Support for svelte preprocessors that provide source maps
+-   Formatting (via [prettier-plugin-svelte](https://github.com/sveltejs/prettier-plugin-svelte))
+-   Hover info
+-   Autocompletions
+-   Go to definition
+
+The extension also comes packaged with a TypeScript plugin, which when activated provides intellisense within JavaScript and TypeScript files for interacting with Svelte files.
 
 ##### `svelte.plugin.XXX`
 

--- a/package.json
+++ b/package.json
@@ -355,6 +355,50 @@
             {
                 "command": "svelte.restartLanguageServer",
                 "title": "Svelte: Restart Language Server"
+            },
+            {
+                "command": "svelte.typescript.findAllFileReferences",
+                "title": "Svelte: Find File References"
+            },
+            {
+                "command": "svelte.typescript.findComponentReferences",
+                "title": "Svelte: Find Component References"
+            },
+            {
+                "command": "svelte.kit.generateMultipleFiles",
+                "title": "SvelteKit: Create route"
+            },
+            {
+                "command": "svelte.kit.generatePage",
+                "title": "SvelteKit: Create +page.svelte"
+            },
+            {
+                "command": "svelte.kit.generatePageLoad",
+                "title": "SvelteKit: Create +page.js/ts"
+            },
+            {
+                "command": "svelte.kit.generatePageServerLoad",
+                "title": "SvelteKit: Create +page.server.js/ts"
+            },
+            {
+                "command": "svelte.kit.generateLayout",
+                "title": "SvelteKit: Create +layout.svelte"
+            },
+            {
+                "command": "svelte.kit.generateLayoutLoad",
+                "title": "SvelteKit: Create +layout.js/ts"
+            },
+            {
+                "command": "svelte.kit.generateLayoutServerLoad",
+                "title": "SvelteKit: Create +layout.server.js/ts"
+            },
+            {
+                "command": "svelte.kit.generateServer",
+                "title": "SvelteKit: Create +server.js/ts"
+            },
+            {
+                "command": "svelte.kit.generateError",
+                "title": "SvelteKit: Create +error.svelte"
             }
         ],
         "submenus": [

--- a/package.json
+++ b/package.json
@@ -28,10 +28,12 @@
     },
     "activationEvents": [
         "onLanguage:svelte",
-        "onCommand:svelte.restartLanguageServer"
+        "onCommand:svelte.restartLanguageServer",
+        "onLanguage:javascript",
+        "onLanguage:typescript"
     ],
     "contributes": {
-        "typescriptServerPlugins-disabled": [
+        "typescriptServerPlugins": [
             {
                 "name": "typescript-svelte-plugin",
                 "enableForWorkspaceTypeScriptVersions": true
@@ -63,7 +65,7 @@
                     "scope": "application",
                     "type": "string",
                     "title": "Language Server Path",
-                    "description": "- You normally don't set this - Path to the language server executable. If you installed the \"svelte-language-server\" npm package, it's within there at \"bin/server.js\". Path can be either relative to your workspace root or absolute. Set this only if you want to use a custom version of the language server. This setting can only be changed in user settings for security reasons."
+                    "description": "- You normally don't set this - Path to the language server executable. If you installed the \"svelte-language-server\" npm package, it's within there at \"bin/server.js\". Path can be either relative to your workspace root or absolute. Set this only if you want to use a custom version of the language server. This will then also use the workspace version of TypeScript. This setting can only be changed in user settings for security reasons."
                 },
                 "svelte.language-server.port": {
                     "type": "number",
@@ -71,17 +73,26 @@
                     "description": "- You normally don't set this - At which port to spawn the language server. Can be used for attaching to the process for debugging / profiling. If you experience crashes due to \"port already in use\", try setting the port. -1 = default port is used.",
                     "default": -1
                 },
+                "svelte.language-server.debug": {
+                    "type": "boolean",
+                    "title": "Language Server Debug Mode",
+                    "description": "- You normally don't set this - Enable more verbose logging for the language server useful for debugging language server execution."
+                },
+                "svelte.ui.svelteKitFilesContextMenu.enable": {
+                    "type": "string",
+                    "default": "auto",
+                    "enum": [
+                        "auto",
+                        "never",
+                        "always"
+                    ],
+                    "description": "Show a context menu to generate SvelteKit files. \"always\" to always show it. \"never\" to always disable it. \"auto\" to show it when in a SvelteKit project. "
+                },
                 "svelte.plugin.typescript.enable": {
                     "type": "boolean",
                     "default": true,
                     "title": "TypeScript",
                     "description": "Enable the TypeScript plugin"
-                },
-                "svelte.plugin.typescript.findReferences.enable": {
-                    "type": "boolean",
-                    "default": true,
-                    "title": "TypeScript: Find References",
-                    "description": "Enable find-references for TypeScript"
                 },
                 "svelte.plugin.typescript.diagnostics.enable": {
                     "type": "boolean",
@@ -124,12 +135,6 @@
                     "default": true,
                     "title": "TypeScript: Signature Help",
                     "description": "Enable signature help (parameter hints) for TypeScript"
-                },
-                "svelte.plugin.typescript.rename.enable": {
-                    "type": "boolean",
-                    "default": true,
-                    "title": "TypeScript: Rename",
-                    "description": "Enable rename functionality for JS/TS variables inside Svelte files"
                 },
                 "svelte.plugin.typescript.codeActions.enable": {
                     "type": "boolean",
@@ -323,6 +328,16 @@
                     "default": true,
                     "title": "Svelte: Rename",
                     "description": "Enable rename/move Svelte files functionality"
+                },
+                "svelte.plugin.svelte.defaultScriptLanguage": {
+                    "type": "string",
+                    "default": "none",
+                    "title": "Svelte: Default Script Language",
+                    "description": "The default language to use when generating new script tags",
+                    "enum": [
+                        "none",
+                        "ts"
+                    ]
                 }
             }
         },
@@ -342,6 +357,12 @@
                 "title": "Svelte: Restart Language Server"
             }
         ],
+        "submenus": [
+            {
+                "id": "sveltekit2files",
+                "label": "SvelteKit Files"
+            }
+        ],
         "breakpoints": [
             {
                 "language": "svelte"
@@ -350,16 +371,16 @@
     },
     "dependencies": {
         "lodash": "^4.17.21",
-        "svelte-language-server": "^0.14.9",
-        "typescript": "^4.4.3",
-        "typescript-svelte-plugin": "^0.2.4",
-        "vscode-languageserver-protocol": "^3.15.3"
+        "svelte-language-server": "*",
+        "typescript": "*",
+        "typescript-svelte-plugin": "*",
+        "vscode-languageserver-protocol": "^3.17.3"
     },
     "devDependencies": {
-        "@tsconfig/node12": "^1.0.0",
+        "@tsconfig/node14": "^1.0.0",
         "@types/lodash": "^4.14.172",
-        "@types/node": "^14.0.1",
-        "coc.nvim": "^0.0.80",
+        "@types/node": "^14.0.0",
+        "coc.nvim": "^0.0.83-next.17",
         "js-yaml": "^3.14.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^3.0.2"

--- a/src/sveltekit/generateFiles/commands.ts
+++ b/src/sveltekit/generateFiles/commands.ts
@@ -1,0 +1,12 @@
+import { CommandType, ResourceType } from './types';
+
+export const addResourceCommandMap = new Map<CommandType, ResourceType>([
+    [CommandType.PAGE, ResourceType.PAGE],
+    [CommandType.PAGE_LOAD, ResourceType.PAGE_LOAD],
+    [CommandType.PAGE_SERVER, ResourceType.PAGE_SERVER],
+    [CommandType.LAYOUT, ResourceType.LAYOUT],
+    [CommandType.LAYOUT_LOAD, ResourceType.LAYOUT_LOAD],
+    [CommandType.LAYOUT_SERVER, ResourceType.LAYOUT_SERVER],
+    [CommandType.SERVER, ResourceType.SERVER],
+    [CommandType.ERROR, ResourceType.ERROR],
+]);

--- a/src/sveltekit/generateFiles/generate.ts
+++ b/src/sveltekit/generateFiles/generate.ts
@@ -1,53 +1,55 @@
-import { Position, Uri, workspace, WorkspaceChange, TextEdit } from 'coc.nvim';
+import {
+    Position,
+    Uri,
+    workspace,
+    WorkspaceEdit,
+    CreateFile,
+    TextDocumentEdit,
+    TextEdit,
+} from 'coc.nvim';
 import { join } from 'path';
 import { FileType, GenerateConfig } from './types';
 
-function getFilePathFromConfig(config: GenerateConfig, resource: GenerateConfig['resources'][0]) {
+function getFilePathFromConfig(
+    config: GenerateConfig,
+    resource: GenerateConfig['resources'][0],
+): string {
     const ext = resource.type === FileType.PAGE ? config.pageExtension : config.scriptExtension;
     return join(config.path, `${resource.filename}.${ext}`);
 }
 
 export async function generateResources(config: GenerateConfig) {
     // The dir may need to be created, but there isn't an easy way in coc.nvim
-    const change = new WorkspaceChange();
+    const filepathsAndResources = config.resources.map(
+        (resource): [string, GenerateConfig['resources'][0]] => [
+            getFilePathFromConfig(config, resource),
+            resource,
+        ],
+    );
 
-    for (const resource of config.resources) {
-        const filepath = getFilePathFromConfig(config, resource);
-        change.createFile(filepath, {
-            overwrite: false,
-            ignoreIfExists: true,
-        });
-    }
-    // Convert change to TextEdit
-    const edit = change.edit;
-
-    for (const resource of config.resources) {
+    for (const [filepath, resource] of filepathsAndResources) {
         const data = await resource.generate(config);
-        const filepath = getFilePathFromConfig(config, resource);
-        const relevantChanges = edit.changes ? edit.changes[filepath] || [] : [];
-        edit.changes = {
-            ...edit.changes,
-            [filepath]: [...relevantChanges, TextEdit.insert(Position.create(0, 0), data)],
-        };
+        await workspace.createFile(filepath)
+        const edits: WorkspaceEdit = {
+          changes: {
+            [filepath]: [TextEdit.insert(Position.create(0, 0), data)]
+          }
+        }
+        workspace.applyEdit(edits)
     }
-
-    await workspace.applyEdit(edit);
 
     // save documents and open the first
-    const changes = edit.changes;
-    if (changes) {
-        await Promise.all(
-            Object.entries(changes).map(async ([uri], i) => {
-                const doc = workspace.textDocuments.find(
-                    (t) => Uri.parse(t.uri).path === Uri.parse(uri).path,
-                );
-                if (doc) {
-                    // double check whether the doc needs to be saved
-                    if (i === 0) {
-                        await workspace.openTextDocument(uri);
-                    }
+    await Promise.all(
+        filepathsAndResources.map(async ([uri], i) => {
+            const doc = workspace.textDocuments.find(
+                (t) => Uri.parse(t.uri).path === Uri.parse(uri).path,
+            );
+            if (doc) {
+                // double check whether the doc needs to be saved
+                if (i === 0) {
+                    await workspace.openTextDocument(uri);
                 }
-            }),
-        );
-    }
+            }
+        }),
+    );
 }

--- a/src/sveltekit/generateFiles/generate.ts
+++ b/src/sveltekit/generateFiles/generate.ts
@@ -1,0 +1,53 @@
+import { Position, Uri, workspace, WorkspaceChange, TextEdit } from 'coc.nvim';
+import { join } from 'path';
+import { FileType, GenerateConfig } from './types';
+
+function getFilePathFromConfig(config: GenerateConfig, resource: GenerateConfig['resources'][0]) {
+    const ext = resource.type === FileType.PAGE ? config.pageExtension : config.scriptExtension;
+    return join(config.path, `${resource.filename}.${ext}`);
+}
+
+export async function generateResources(config: GenerateConfig) {
+    // The dir may need to be created, but there isn't an easy way in coc.nvim
+    const change = new WorkspaceChange();
+
+    for (const resource of config.resources) {
+        const filepath = getFilePathFromConfig(config, resource);
+        change.createFile(filepath, {
+            overwrite: false,
+            ignoreIfExists: true,
+        });
+    }
+    // Convert change to TextEdit
+    const edit = change.edit;
+
+    for (const resource of config.resources) {
+        const data = await resource.generate(config);
+        const filepath = getFilePathFromConfig(config, resource);
+        const relevantChanges = edit.changes ? edit.changes[filepath] || [] : [];
+        edit.changes = {
+            ...edit.changes,
+            [filepath]: [...relevantChanges, TextEdit.insert(Position.create(0, 0), data)],
+        };
+    }
+
+    await workspace.applyEdit(edit);
+
+    // save documents and open the first
+    const changes = edit.changes;
+    if (changes) {
+        await Promise.all(
+            Object.entries(changes).map(async ([uri], i) => {
+                const doc = workspace.textDocuments.find(
+                    (t) => Uri.parse(t.uri).path === Uri.parse(uri).path,
+                );
+                if (doc) {
+                    // double check whether the doc needs to be saved
+                    if (i === 0) {
+                        await workspace.openTextDocument(uri);
+                    }
+                }
+            }),
+        );
+    }
+}

--- a/src/sveltekit/generateFiles/index.ts
+++ b/src/sveltekit/generateFiles/index.ts
@@ -1,0 +1,144 @@
+import * as path from 'path';
+import { commands, ExtensionContext, Uri, window, workspace } from 'coc.nvim';
+import { addResourceCommandMap } from './commands';
+import { generateResources } from './generate';
+import { resourcesMap } from './resources';
+import { FileType, ResourceType, GenerateConfig, CommandType } from './types';
+import { checkProjectType } from '../utils';
+
+class GenerateError extends Error {}
+
+export function addGenerateKitRouteFilesCommand(context: ExtensionContext) {
+    addResourceCommandMap.forEach((value, key) => {
+        context.subscriptions.push(
+            commands.registerCommand(key, (args) => {
+                handleSingle(args, value).catch(handleError);
+            }),
+        );
+    });
+    context.subscriptions.push(
+        commands.registerCommand(CommandType.MULTIPLE, async (args) => {
+            handleMultiple(args).catch(handleError);
+        }),
+    );
+}
+
+async function handleError(err: unknown) {
+    if (err instanceof GenerateError) {
+        await window.showErrorMessage(err.message);
+    } else {
+        throw err;
+    }
+}
+
+async function handleSingle(uri: Uri | undefined, resourceType: ResourceType) {
+    const resource = resourcesMap.get(resourceType);
+    if (!resource) {
+        throw new GenerateError(`Resource '${resourceType}' does not exist`);
+    }
+    const resources = [resource];
+
+    const { type, rootPath, scriptExtension } = await getCommonConfig(uri);
+
+    const itemPath = await promptResourcePath();
+
+    if (!itemPath) {
+        return;
+    }
+
+    await generate({
+        path: path.join(rootPath, itemPath),
+        type,
+        pageExtension: 'svelte',
+        scriptExtension,
+        resources,
+    });
+}
+
+async function handleMultiple(uri: Uri | undefined) {
+    const { type, rootPath, scriptExtension } = await getCommonConfig(uri);
+    const itemPath = await promptResourcePath();
+
+    if (!itemPath) {
+        return;
+    }
+
+    // Add multiple files
+    const opts = [
+        ResourceType.PAGE,
+        ResourceType.PAGE_LOAD,
+        ResourceType.PAGE_SERVER,
+        ResourceType.LAYOUT,
+        ResourceType.LAYOUT_LOAD,
+        ResourceType.LAYOUT_SERVER,
+        ResourceType.ERROR,
+        ResourceType.SERVER,
+    ].map((type) => {
+        const resource = resourcesMap.get(type)!;
+        // const iconName = resource.type === FileType.PAGE ? 'svelte' : isTs ? 'typescript' : 'javascript';
+        const extension = resource.type === FileType.PAGE ? 'svelte' : scriptExtension;
+        return {
+            // TODO: maybe add icons (ts,js,svelte - but it doesn´t work like this)
+            // description: `$(${iconName}) ${resource.filename}.${extension}`,
+            label: `${resource.filename}.${extension}`,
+            value: resource,
+        };
+    });
+    const result = await window.showQuickPick(opts, { canPickMany: true });
+
+    if (!result) {
+        return;
+    }
+
+    await generate({
+        path: path.join(rootPath, itemPath),
+        type,
+        pageExtension: 'svelte',
+        scriptExtension,
+        resources: result.map((res) => res.value),
+    });
+}
+
+async function promptResourcePath() {
+    const itemPath = await window.requestInput(
+        'Enter the path of the resources, relative to current folder',
+        '/',
+    );
+
+    return itemPath;
+}
+
+async function generate(config: GenerateConfig) {
+    await window.withProgress({ title: 'Creating SvelteKit files...' }, async () => {
+        await generateResources(config);
+    });
+}
+
+async function getCommonConfig(uri: Uri | undefined) {
+    const rootPath = getRootPath(uri);
+    if (!rootPath) {
+        throw new GenerateError(
+            'Could not resolve root path. Please open a file first or use the context menu!',
+        );
+    }
+
+    const type = await checkProjectType(rootPath);
+    const scriptExtension = type === 'js' ? 'js' : 'ts';
+    return {
+        type,
+        scriptExtension,
+        rootPath,
+    } as const;
+}
+
+function getRootPath(uri: Uri | undefined) {
+    let rootPath!: string;
+    if (uri) {
+        rootPath = uri.fsPath;
+    } else if (window.activeTextEditor) {
+        rootPath = path.dirname(Uri.parse(window.activeTextEditor.document.uri).path);
+    } else if (workspace.workspaceFolders && workspace.workspaceFolders.length === 1) {
+        rootPath = Uri.parse(workspace.workspaceFolders[0].uri).fsPath;
+    }
+    return rootPath;
+}

--- a/src/sveltekit/generateFiles/resources.ts
+++ b/src/sveltekit/generateFiles/resources.ts
@@ -1,0 +1,38 @@
+import { FileType, Resource, ResourceType } from './types';
+
+import page from './templates/page';
+import pageLoad from './templates/page-load';
+import pageServer from './templates/page-server';
+import layout from './templates/layout';
+import layoutLoad from './templates/layout-load';
+import layoutServer from './templates/layout-server';
+import error from './templates/error';
+import server from './templates/server';
+
+export const resourcesMap = new Map<ResourceType, Resource>([
+    [ResourceType.PAGE, { type: FileType.PAGE, filename: '+page', generate: page }],
+    [ResourceType.PAGE_LOAD, { type: FileType.SCRIPT, filename: '+page', generate: pageLoad }],
+    [
+        ResourceType.PAGE_SERVER,
+        {
+            type: FileType.SCRIPT,
+            filename: '+page.server',
+            generate: pageServer
+        }
+    ],
+    [ResourceType.LAYOUT, { type: FileType.PAGE, filename: '+layout', generate: layout }],
+    [
+        ResourceType.LAYOUT_LOAD,
+        { type: FileType.SCRIPT, filename: '+layout', generate: layoutLoad }
+    ],
+    [
+        ResourceType.LAYOUT_SERVER,
+        {
+            type: FileType.SCRIPT,
+            filename: '+layout.server',
+            generate: layoutServer
+        }
+    ],
+    [ResourceType.SERVER, { type: FileType.SCRIPT, filename: '+server', generate: server }],
+    [ResourceType.ERROR, { type: FileType.PAGE, filename: '+error', generate: error }]
+]);

--- a/src/sveltekit/generateFiles/templates/error.ts
+++ b/src/sveltekit/generateFiles/templates/error.ts
@@ -1,0 +1,21 @@
+import { GenerateConfig } from '../types';
+
+export default async function (config: GenerateConfig) {
+    const ts = `
+<script lang="ts">
+    import { page } from '$app/stores';
+</script>
+
+<h1>{$page.status}: {$page.error?.message}</h1>
+    `.trim();
+
+    const js = `
+<script>
+    import { page } from '$app/stores';
+</script>
+
+<h1>{$page.status}: {$page.error.message}</h1>
+    `.trim();
+
+    return config.type === 'js' ? js : ts;
+}

--- a/src/sveltekit/generateFiles/templates/layout-load.ts
+++ b/src/sveltekit/generateFiles/templates/layout-load.ts
@@ -1,0 +1,28 @@
+import { GenerateConfig } from '../types';
+
+export default async function (config: GenerateConfig) {
+    const ts = `
+import type { LayoutLoad } from './$types';
+
+export const load: LayoutLoad = async () => {
+    return {};
+};
+    `.trim();
+
+    const tsSatisfies = `
+import type { LayoutLoad } from './$types';
+
+export const load = (async () => {
+    return {};
+}) satisfies LayoutLoad;
+    `.trim();
+
+    const js = `
+/** @type {import('./$types').LayoutLoad} */
+export async function load() {
+    return {};
+}
+    `.trim();
+
+    return config.type === 'js' ? js : config.type === 'ts' ? ts : tsSatisfies;
+}

--- a/src/sveltekit/generateFiles/templates/layout-server.ts
+++ b/src/sveltekit/generateFiles/templates/layout-server.ts
@@ -1,0 +1,28 @@
+import { GenerateConfig } from '../types';
+
+export default async function (config: GenerateConfig) {
+    const ts = `
+import type { LayoutServerLoad } from './$types';
+
+export const load: LayoutServerLoad = async () => {
+    return {};
+};
+    `.trim();
+
+    const tsSatisfies = `
+import type { LayoutServerLoad } from './$types';
+
+export const load = (async () => {
+    return {};
+}) satisfies LayoutServerLoad;
+    `.trim();
+
+    const js = `
+/** @type {import('./$types').LayoutServerLoad} */
+export async function load() {
+    return {};
+}
+    `.trim();
+
+    return config.type === 'js' ? js : config.type === 'ts' ? ts : tsSatisfies;
+}

--- a/src/sveltekit/generateFiles/templates/layout.ts
+++ b/src/sveltekit/generateFiles/templates/layout.ts
@@ -1,0 +1,20 @@
+import { GenerateConfig } from '../types';
+
+export default async function (config: GenerateConfig) {
+    const ts = `
+<script lang="ts">
+    import type { LayoutData } from './$types';
+
+    export let data: LayoutData;
+</script>
+    `.trim();
+
+    const js = `
+<script>
+    /** @type {import('./$types').LayoutData} */
+    export let data;
+</script>
+    `.trim();
+
+    return config.type === 'js' ? js : ts;
+}

--- a/src/sveltekit/generateFiles/templates/page-load.ts
+++ b/src/sveltekit/generateFiles/templates/page-load.ts
@@ -1,0 +1,28 @@
+import { GenerateConfig } from '../types';
+
+export default async function (config: GenerateConfig) {
+    const ts = `
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async () => {
+    return {};
+};
+    `.trim();
+
+    const tsSatisfies = `
+import type { PageLoad } from './$types';
+
+export const load = (async () => {
+    return {};
+}) satisfies PageLoad;
+    `.trim();
+
+    const js = `
+/** @type {import('./$types').PageLoad} */
+export async function load() {
+    return {};
+};
+    `.trim();
+
+    return config.type === 'js' ? js : config.type === 'ts' ? ts : tsSatisfies;
+}

--- a/src/sveltekit/generateFiles/templates/page-server.ts
+++ b/src/sveltekit/generateFiles/templates/page-server.ts
@@ -1,0 +1,28 @@
+import { GenerateConfig } from '../types';
+
+export default async function (config: GenerateConfig) {
+    const ts = `
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async () => {
+    return {};
+};
+    `.trim();
+
+    const tsSatisfies = `
+import type { PageServerLoad } from './$types';
+
+export const load = (async () => {
+    return {};
+}) satisfies PageServerLoad;
+    `.trim();
+
+    const js = `
+/** @type {import('./$types').PageServerLoad} */
+export async function load() {
+    return {};
+};
+    `.trim();
+
+    return config.type === 'js' ? js : config.type === 'ts' ? ts : tsSatisfies;
+}

--- a/src/sveltekit/generateFiles/templates/page.ts
+++ b/src/sveltekit/generateFiles/templates/page.ts
@@ -1,0 +1,20 @@
+import { GenerateConfig } from '../types';
+
+export default async function (config: GenerateConfig) {
+    const ts = `
+<script lang="ts">
+    import type { PageData } from './$types';
+
+    export let data: PageData;
+</script>
+    `.trim();
+
+    const js = `
+<script>
+    /** @type {import('./$types').PageData} */
+    export let data;
+</script>
+    `.trim();
+
+    return config.type === 'js' ? js : ts;
+}

--- a/src/sveltekit/generateFiles/templates/server.ts
+++ b/src/sveltekit/generateFiles/templates/server.ts
@@ -1,0 +1,20 @@
+import { GenerateConfig } from '../types';
+
+export default async function generate(config: GenerateConfig) {
+    const ts = `
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async () => {
+    return new Response();
+};
+    `.trim();
+
+    const js = `
+/** @type {import('./$types').RequestHandler} */
+export async function GET() {
+    return new Response();
+};
+    `.trim();
+
+    return config.type === 'js' ? js : ts;
+}

--- a/src/sveltekit/generateFiles/types.ts
+++ b/src/sveltekit/generateFiles/types.ts
@@ -1,0 +1,41 @@
+export enum CommandType {
+    PAGE = 'svelte.kit.generatePage',
+    PAGE_LOAD = 'svelte.kit.generatePageLoad',
+    PAGE_SERVER = 'svelte.kit.generatePageServerLoad',
+    LAYOUT = 'svelte.kit.generateLayout',
+    LAYOUT_LOAD = 'svelte.kit.generateLayoutLoad',
+    LAYOUT_SERVER = 'svelte.kit.generateLayoutServerLoad',
+    SERVER = 'svelte.kit.generateServer',
+    ERROR = 'svelte.kit.generateError',
+    MULTIPLE = 'svelte.kit.generateMultipleFiles'
+}
+
+export enum FileType {
+    SCRIPT,
+    PAGE
+}
+
+export enum ResourceType {
+    PAGE,
+    PAGE_LOAD,
+    PAGE_SERVER,
+    LAYOUT,
+    LAYOUT_LOAD,
+    LAYOUT_SERVER,
+    SERVER,
+    ERROR
+}
+
+export type Resource = {
+    type: FileType;
+    filename: string;
+    generate: (config: GenerateConfig) => Promise<string>;
+};
+
+export interface GenerateConfig {
+    path: string;
+    type: 'js' | 'ts' | 'ts-satisfies';
+    pageExtension: string;
+    scriptExtension: string;
+    resources: Resource[];
+}

--- a/src/sveltekit/index.ts
+++ b/src/sveltekit/index.ts
@@ -17,20 +17,17 @@ export function setupSvelteKit(context: ExtensionContext) {
     async function enableContextMenu() {
         const config = getConfig();
         if (config === 'never') {
-            if (contextMenuEnabled) {
-                setEnableContext(false);
-            }
             return;
         }
 
         if (config === 'always') {
             // Force on. The condition is defined in the extension manifest
+            contextMenuEnabled = true
             return;
         }
 
         const enabled = await detect(20);
         if (enabled !== contextMenuEnabled) {
-            setEnableContext(enabled);
             contextMenuEnabled = enabled;
         }
     }
@@ -70,13 +67,4 @@ async function detect(nrRetries: number): Promise<boolean> {
     }
 
     return false;
-}
-
-function setEnableContext(enable: boolean) {
-    // https://code.visualstudio.com/api/references/when-clause-contexts#add-a-custom-when-clause-context
-    commands.executeCommand(
-        'setContext',
-        'svelte.uiContext.svelteKitFilesContextMenu.enable',
-        enable,
-    );
 }

--- a/src/sveltekit/index.ts
+++ b/src/sveltekit/index.ts
@@ -1,0 +1,82 @@
+import { ExtensionContext, commands, workspace } from 'coc.nvim';
+import { addGenerateKitRouteFilesCommand } from './generateFiles';
+
+type ShowSvelteKitFilesContextMenuConfig = 'auto' | 'always' | 'never';
+
+export function setupSvelteKit(context: ExtensionContext) {
+    let contextMenuEnabled = false;
+    context.subscriptions.push(
+        workspace.onDidChangeConfiguration(() => {
+            enableContextMenu();
+        }),
+    );
+
+    addGenerateKitRouteFilesCommand(context);
+    enableContextMenu();
+
+    async function enableContextMenu() {
+        const config = getConfig();
+        if (config === 'never') {
+            if (contextMenuEnabled) {
+                setEnableContext(false);
+            }
+            return;
+        }
+
+        if (config === 'always') {
+            // Force on. The condition is defined in the extension manifest
+            return;
+        }
+
+        const enabled = await detect(20);
+        if (enabled !== contextMenuEnabled) {
+            setEnableContext(enabled);
+            contextMenuEnabled = enabled;
+        }
+    }
+}
+
+function getConfig() {
+    return (
+        workspace
+            .getConfiguration('svelte.ui.svelteKitFilesContextMenu')
+            .get<ShowSvelteKitFilesContextMenuConfig>('enable') ?? 'auto'
+    );
+}
+
+async function detect(nrRetries: number): Promise<boolean> {
+    const packageJsonList = await workspace.findFiles('**/package.json', '**/node_modules/**');
+
+    if (packageJsonList.length === 0 && nrRetries > 0) {
+        // We assume that the user has not setup their project yet, so try again after a while
+        await new Promise((resolve) => setTimeout(resolve, 10000));
+        return detect(nrRetries - 1);
+    }
+
+    for (const fileUri of packageJsonList) {
+        try {
+            const text = await workspace.readFile(fileUri.toString());
+            const pkg = JSON.parse(text);
+            const hasKit = Object.keys(pkg.devDependencies ?? {})
+                .concat(Object.keys(pkg.dependencies ?? {}))
+                .includes('@sveltejs/kit');
+
+            if (hasKit) {
+                return true;
+            }
+        } catch (error) {
+            console.error(error);
+        }
+    }
+
+    return false;
+}
+
+function setEnableContext(enable: boolean) {
+    // https://code.visualstudio.com/api/references/when-clause-contexts#add-a-custom-when-clause-context
+    commands.executeCommand(
+        'setContext',
+        'svelte.uiContext.svelteKitFilesContextMenu.enable',
+        enable,
+    );
+}

--- a/src/sveltekit/utils.ts
+++ b/src/sveltekit/utils.ts
@@ -1,0 +1,49 @@
+import { workspace } from 'coc.nvim';
+import * as path from 'path';
+
+export async function fileExists(file: string) {
+    try {
+        const path = await workspace.findUp(file);
+        return Boolean(path);
+    } catch (err) {
+        return false;
+    }
+}
+
+export async function findFile(searchPath: string, fileName: string) {
+    for (;;) {
+        const filePath = path.join(searchPath, fileName);
+        if (await fileExists(filePath)) {
+            return filePath;
+        }
+        const parentPath = path.dirname(searchPath);
+        if (parentPath === searchPath) {
+            return;
+        }
+        searchPath = parentPath;
+    }
+}
+
+export async function checkProjectType(path: string) {
+    const tsconfig = await findFile(path, 'tsconfig.json');
+    const jsconfig = await findFile(path, 'jsconfig.json');
+    const isTs = !!tsconfig && (!jsconfig || tsconfig.length >= jsconfig.length);
+    if (isTs) {
+        try {
+            const packageJSONPath = require.resolve('typescript/package.json', {
+                paths: [tsconfig],
+            });
+            const { version } = require(packageJSONPath);
+            const [major, minor] = version.split('.');
+            if ((Number(major) === 4 && Number(minor) >= 9) || Number(major) > 4) {
+                return 'ts-satisfies';
+            } else {
+                return 'ts';
+            }
+        } catch (e) {
+            return 'ts';
+        }
+    } else {
+        return 'js';
+    }
+}

--- a/src/tsplugin.ts
+++ b/src/tsplugin.ts
@@ -25,13 +25,7 @@ export class TsPlugin {
     }
 
     private async toggleTsPlugin(enable: boolean) {
-        // This somewhat semi-public command configures our TypeScript plugin.
-        // The plugin itself is always present, but enabled/disabled depending on this config.
-        // It is done this way because it allows us to toggle the plugin without restarting VS Code
-        // and without having to do hacks like updating the extension's package.json.
-        commands.executeCommand('_typescript.configurePlugin', 'typescript-svelte-plugin', {
-            enable,
-        });
+        workspace.getConfiguration('svelte').update('enable-ts-plugin', enable, true);
     }
 
     async askToEnable() {

--- a/src/tsplugin.ts
+++ b/src/tsplugin.ts
@@ -1,24 +1,17 @@
-import { readFileSync, writeFileSync } from 'fs';
-import { join } from 'path';
 import { commands, ExtensionContext, window, workspace } from 'coc.nvim';
 
 export class TsPlugin {
     private enabled: boolean;
-    private context: ExtensionContext;
+    context: ExtensionContext;
 
-    static create(context: ExtensionContext) {
-        new TsPlugin(context);
-    }
-
-    private constructor(context: ExtensionContext) {
-        this.enabled = this.getEnabledState();
-        this.askToEnable(this.enabled);
+    constructor(context: ExtensionContext) {
+        this.enabled = this.isEnabled();
         this.context = context;
         this.toggleTsPlugin(this.enabled);
 
         context.subscriptions.push(
             workspace.onDidChangeConfiguration(() => {
-                const enabled = this.getEnabledState();
+                const enabled = this.isEnabled();
                 if (enabled !== this.enabled) {
                     this.enabled = enabled;
                     this.toggleTsPlugin(this.enabled);
@@ -27,56 +20,25 @@ export class TsPlugin {
         );
     }
 
-    private getEnabledState(): boolean {
+    private isEnabled(): boolean {
         return workspace.getConfiguration('svelte').get<boolean>('enable-ts-plugin') ?? false;
     }
 
-    private toggleTsPlugin(enable: boolean) {
-        const extension = this.context;
-
-        const packageJson = join(extension.extensionPath, 'package.json');
-        const enabled = '"typescriptServerPlugins"';
-        const disabled = '"typescriptServerPlugins-disabled"';
-        try {
-            const packageText = readFileSync(packageJson, 'utf8');
-            if (packageText.includes(disabled) && enable) {
-                const newText = packageText.replace(disabled, enabled);
-                writeFileSync(packageJson, newText, 'utf8');
-                this.showReload(true);
-            } else if (packageText.includes(enabled) && !enable) {
-                const newText = packageText.replace(enabled, disabled);
-                writeFileSync(packageJson, newText, 'utf8');
-                this.showReload(false);
-            } else if (!packageText.includes(enabled) && !packageText.includes(disabled)) {
-                window.showWarningMessage('Unknown coc-svelte package.json status.');
-            }
-        } catch (err) {
-            window.showWarningMessage(
-                'coc-svelte package.json update failed, TypeScript plugin could not be toggled.',
-            );
-        }
+    private async toggleTsPlugin(enable: boolean) {
+        // This somewhat semi-public command configures our TypeScript plugin.
+        // The plugin itself is always present, but enabled/disabled depending on this config.
+        // It is done this way because it allows us to toggle the plugin without restarting VS Code
+        // and without having to do hacks like updating the extension's package.json.
+        commands.executeCommand('_typescript.configurePlugin', 'typescript-svelte-plugin', {
+            enable,
+        });
     }
 
-    private async showReload(enabled: boolean) {
-        // Restarting the TSServer via a command isn't enough, the whole coc-svelte window needs to reload
-        let message = `TypeScript Svelte Plugin ${enabled ? 'enabled' : 'disabled'}.`;
-        if (enabled) {
-            message +=
-                ' Note that changes of Svelte files are only noticed by TS/JS files after they are saved to disk.';
-        }
-        message += ' Please reload coc-svelte to restart the TS Server.';
-
-        const reload = await window.showInformationMessage(message, 'Reload Window');
-        if (reload) {
-            commands.executeCommand('workbench.action.reloadWindow');
-        }
-    }
-
-    private async askToEnable(enabled: boolean) {
+    async askToEnable() {
         const shouldAsk = workspace
             .getConfiguration('svelte')
             .get<boolean>('ask-to-enable-ts-plugin');
-        if (enabled || !shouldAsk) {
+        if (this.enabled || !shouldAsk) {
             return;
         }
 

--- a/src/typescript/findComponentReferences.ts
+++ b/src/typescript/findComponentReferences.ts
@@ -1,0 +1,71 @@
+import {
+    commands,
+    LanguageClient,
+    ExtensionContext,
+    Uri,
+    window,
+    workspace,
+    Position,
+    Location,
+    Range,
+} from 'coc.nvim';
+import { Location as LSLocation } from 'vscode-languageserver-protocol';
+
+export async function addFindComponentReferencesListener(
+    getLS: () => LanguageClient,
+    context: ExtensionContext,
+) {
+    const disposable = commands.registerCommand(
+        'svelte.typescript.findComponentReferences',
+        handler,
+    );
+
+    context.subscriptions.push(disposable);
+
+    async function handler(resource?: Uri) {
+        if (!resource) {
+            const documentUriString = window.activeTextEditor?.document.uri;
+            resource = documentUriString ? Uri.parse(documentUriString) : undefined;
+        }
+
+        if (!resource || resource.scheme !== 'file') {
+            return;
+        }
+
+        const document = await workspace.openTextDocument(resource);
+
+        await window.withProgress(
+            {
+                title: 'Finding component references',
+            },
+            async (_, token) => {
+                const lsLocations = await getLS().sendRequest<LSLocation[] | null>(
+                    '$/getComponentReferences',
+                    document.uri.toString(),
+                    token,
+                );
+
+                if (!lsLocations) {
+                    return;
+                }
+
+                await commands.executeCommand(
+                    'editor.action.showReferences',
+                    resource,
+                    Position.create(0, 0),
+                    lsLocations.map((ref) =>
+                        Location.create(
+                            ref.uri,
+                            Range.create(
+                                ref.range.start.line,
+                                ref.range.start.character,
+                                ref.range.end.line,
+                                ref.range.end.character,
+                            ),
+                        ),
+                    ),
+                );
+            },
+        );
+    }
+}

--- a/src/typescript/findFileReferences.ts
+++ b/src/typescript/findFileReferences.ts
@@ -1,0 +1,82 @@
+import {
+    commands,
+    ExtensionContext,
+    LanguageClient,
+    Uri,
+    window,
+    workspace,
+    Position,
+    Location,
+    Range,
+} from 'coc.nvim';
+import { Location as LSLocation } from 'vscode-languageserver-protocol';
+
+/**
+ * adopted from https://github.com/microsoft/vscode/blob/5f3e9c120a4407de3e55465588ce788618526eb0/extensions/typescript-language-features/src/languageFeatures/fileReferences.ts
+ */
+export async function addFindFileReferencesListener(
+    getLS: () => LanguageClient,
+    context: ExtensionContext,
+) {
+    const disposable = commands.registerCommand('svelte.typescript.findAllFileReferences', handler);
+
+    context.subscriptions.push(disposable);
+
+    async function handler(resource?: Uri) {
+        if (!resource) {
+            const documentUriString = window.activeTextEditor?.document.uri;
+            resource = documentUriString ? Uri.parse(documentUriString) : undefined;
+        }
+
+        if (!resource || resource.scheme !== 'file') {
+            return;
+        }
+
+        const document = await workspace.openTextDocument(resource);
+
+        await window.withProgress(
+            {
+                title: 'Finding file references',
+            },
+            async (_, token) => {
+                const lsLocations = await getLS().sendRequest<LSLocation[] | null>(
+                    '$/getFileReferences',
+                    document.uri.toString(),
+                    token,
+                );
+
+                if (!lsLocations) {
+                    return;
+                }
+
+                const config = workspace.getConfiguration('references');
+                const existingSetting = config.inspect<string>('preferredLocation');
+
+                await config.update('preferredLocation', 'view');
+                try {
+                    await commands.executeCommand(
+                        'editor.action.showReferences',
+                        resource,
+                        Position.create(0, 0),
+                        lsLocations.map((ref) =>
+                            Location.create(
+                                ref.uri,
+                                Range.create(
+                                    ref.range.start.line,
+                                    ref.range.start.character,
+                                    ref.range.end.line,
+                                    ref.range.end.character,
+                                ),
+                            ),
+                        ),
+                    );
+                } finally {
+                    await config.update(
+                        'preferredLocation',
+                        existingSetting?.workspaceFolderValue ?? existingSetting?.workspaceValue,
+                    );
+                }
+            },
+        );
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "@tsconfig/node12/tsconfig.json",
+    "extends": "@tsconfig/node14/tsconfig.json",
     "compilerOptions": {
         "moduleResolution": "node",
         "strict": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,24 +2,47 @@
 # yarn lockfile v1
 
 
-"@emmetio/abbreviation@^2.2.2":
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/@emmetio/abbreviation/-/abbreviation-2.2.2.tgz#746762fd9e7a8c2ea604f580c62e3cfe250e6989"
-  integrity sha512-TtE/dBnkTCct8+LntkqVrwqQao6EnPAs1YN3cUgxOxTaBlesBCY37ROUAVZrRlG64GNnVShdl/b70RfAI3w5lw==
+"@emmetio/abbreviation@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@emmetio/abbreviation/-/abbreviation-2.3.1.tgz#b5ec06b9629ec63292f3a378e716dcb3071924ea"
+  integrity sha512-QXgYlXZGprqb6aCBJPPWVBN/Jb69khJF73GGJkOk//PoMgSbPGuaHn1hCRolctnzlBHjCIC6Om97Pw46/1A23g==
   dependencies:
-    "@emmetio/scanner" "^1.0.0"
+    "@emmetio/scanner" "^1.0.2"
 
-"@emmetio/css-abbreviation@^2.1.4":
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/@emmetio/css-abbreviation/-/css-abbreviation-2.1.4.tgz#90362e8a1122ce3b76f6c3157907d30182f53f54"
-  integrity sha512-qk9L60Y+uRtM5CPbB0y+QNl/1XKE09mSO+AhhSauIfr2YOx/ta3NJw2d8RtCFxgzHeRqFRr8jgyzThbu+MZ4Uw==
+"@emmetio/css-abbreviation@^2.1.6":
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/@emmetio/css-abbreviation/-/css-abbreviation-2.1.6.tgz#f37f7ffb8d76efc40d3629739758531bbe810d7b"
+  integrity sha512-bvuPogt0OvwcILRg+ZD/oej1H72xwOhUDPWOmhCWLJrZZ8bMTazsWnvw8a8noaaVqUhOE9PsC0tYgGVv5N7fsw==
   dependencies:
-    "@emmetio/scanner" "^1.0.0"
+    "@emmetio/scanner" "^1.0.2"
 
-"@emmetio/scanner@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@emmetio/scanner/-/scanner-1.0.0.tgz#065b2af6233fe7474d44823e3deb89724af42b5f"
-  integrity sha512-8HqW8EVqjnCmWXVpqAOZf+EGESdkR27odcMMMGefgKXtar00SoYNSryGv//TELI4T3QFsECo78p+0lmalk/CFA==
+"@emmetio/scanner@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@emmetio/scanner/-/scanner-1.0.2.tgz#ee96ecb9f9cfa5f7a876a13011ae74ee06e9100d"
+  integrity sha512-1ESCGgXRgn1r29hRmz8K0G4Ywr5jDWezMgRnICComBCWmg3znLWU8+tmakuM1og1Vn4W/sauvlABl/oq2pve8w==
+
+"@jridgewell/resolve-uri@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
+  integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
+
+"@jridgewell/sourcemap-codec@1.4.14":
+  version "1.4.14"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
+  integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
+
+"@jridgewell/sourcemap-codec@^1.4.13", "@jridgewell/sourcemap-codec@^1.4.14":
+  version "1.4.15"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
+  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
+"@jridgewell/trace-mapping@^0.3.17":
+  version "0.3.18"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz#25783b2086daf6ff1dcb53c9249ae480e4dd4cd6"
+  integrity sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==
+  dependencies:
+    "@jridgewell/resolve-uri" "3.1.0"
+    "@jridgewell/sourcemap-codec" "1.4.14"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -42,37 +65,41 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@tsconfig/node12@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.0.tgz"
-  integrity sha512-5yHnOI3nejtG2Ak55PRb4SduB14LNMZhihTI0zpKQBCVVuB4h7H1enwoDwhY/8/hC9aPIY8DeZTJzQpk2kZOGA==
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
 
 "@types/lodash@^4.14.172":
   version "4.14.172"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.172.tgz#aad774c28e7bfd7a67de25408e03ee5a8c3d028a"
   integrity sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw==
 
-"@types/node@*":
-  version "16.10.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.10.2.tgz#5764ca9aa94470adb4e1185fe2e9f19458992b2e"
-  integrity sha512-zCclL4/rx+W5SQTzFs9wyvvyCwoK9QtBpratqz2IYJ3O8Umrn0m3nsTv0wQBk9sRGpvUe9CwPDrQFB10f1FIjQ==
+"@types/node@^14.0.0":
+  version "14.18.42"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.42.tgz#fa39b2dc8e0eba61bdf51c66502f84e23b66e114"
+  integrity sha512-xefu+RBie4xWlK8hwAzGh3npDz/4VhF6icY/shU+zv/1fNn+ZVG7T7CRwe9LId9sAYRPxI+59QBPuKL3WpyGRg==
 
-"@types/node@^14.0.1":
-  version "14.0.13"
-  resolved "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz"
-  integrity sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==
+"@types/pug@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@types/pug/-/pug-2.0.6.tgz#f830323c88172e66826d0bde413498b61054b5a6"
+  integrity sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==
 
-"@types/pug@^2.0.4":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@types/pug/-/pug-2.0.5.tgz#69bc700934dd473c7ab97270bd2dbacefe562231"
-  integrity sha512-LOnASQoeNZMkzexRuyqcBBDZ6rS+rQxUMkmj5A0PkhhiSZivLIuz6Hxyr1mkGoEZEkk66faROmpMi4fFkrKsBA==
-
-"@types/sass@^1.16.0":
-  version "1.16.1"
-  resolved "https://registry.yarnpkg.com/@types/sass/-/sass-1.16.1.tgz#cf465bd1fea486d0331f760db023de14daf4980d"
-  integrity sha512-iZUcRrGuz/Tbg3loODpW7vrQJkUtpY2fFSf4ELqqkApcS2TkZ1msk7ie8iZPB86lDOP8QOTTmuvWjc5S0R9OjQ==
+"@vscode/emmet-helper@^2.8.4":
+  version "2.8.7"
+  resolved "https://registry.yarnpkg.com/@vscode/emmet-helper/-/emmet-helper-2.8.7.tgz#48d95466ea12a2c0b272f08f586a648498e5d94f"
+  integrity sha512-y67wWaWBhlWKMX3FNOXcMPh83+xS31IqobBP6vi3HkMRxv14Bti3xgu+ya/c3oKZ0OM/QMvO+oBCwGWqbPv7Rw==
   dependencies:
-    "@types/node" "*"
+    emmet "^2.4.2"
+    jsonc-parser "^2.3.0"
+    vscode-languageserver-textdocument "^1.0.1"
+    vscode-languageserver-types "^3.15.1"
+    vscode-uri "^2.1.2"
+
+"@vscode/l10n@^0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@vscode/l10n/-/l10n-0.0.13.tgz#f51ff130b8c98f189476c5f812d214b8efb09590"
+  integrity sha512-A3uY356uOU9nGa+TQIT/i3ziWUgJjVMUrGGXSrtRiTwklyCFjGVWIOHoEIHbJpiyhDkJd9kvIWUOfXK1IkK8XQ==
 
 ansi-styles@^3.2.1:
   version "3.2.1"
@@ -121,6 +148,11 @@ braces@^3.0.1, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
+buffer-crc32@^0.2.5:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  integrity sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
+
 call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
@@ -153,10 +185,10 @@ chokidar@^3.4.1:
   optionalDependencies:
     fsevents "~2.3.2"
 
-coc.nvim@^0.0.80:
-  version "0.0.80"
-  resolved "https://registry.npmjs.org/coc.nvim/-/coc.nvim-0.0.80.tgz"
-  integrity sha512-/3vTcnofoAYMrdENrlQmADTzfXX4+PZ0fiM10a39UA37dTR2dpIGi9O469kcIksuunLjToqWG8S45AGx/9wV7g==
+coc.nvim@^0.0.83-next.17:
+  version "0.0.83-next.17"
+  resolved "https://registry.yarnpkg.com/coc.nvim/-/coc.nvim-0.0.83-next.17.tgz#a1c4baa10927886366241ca0fd3acc7c941a5546"
+  integrity sha512-VjGnxjbvBOboddNQMI5rZnS0HS0tdft9pbnwste5CncPNJaxfz5wEdWd7eFtifukE8STdLltPMNsoO0vul5r/A==
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -198,18 +230,18 @@ define-properties@^1.1.3:
   dependencies:
     object-keys "^1.0.12"
 
-detect-indent@^6.0.0:
+detect-indent@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.1.0.tgz#592485ebbbf6b3b1ab2be175c8393d04ca0d57e6"
   integrity sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==
 
-emmet@^2.1.5:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/emmet/-/emmet-2.3.4.tgz#5ba0d7a5569a68c7697dfa890c772e4f3179d123"
-  integrity sha512-3IqSwmO+N2ZGeuhDyhV/TIOJFUbkChi53bcasSNRE7Yd+4eorbbYz4e53TpMECt38NtYkZNupQCZRlwdAYA42A==
+emmet@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/emmet/-/emmet-2.4.2.tgz#686983e7b8623ad582fc9fbb6515b17d195c0394"
+  integrity sha512-YgmsMkhUgzhJMgH5noGudfxqrQn1bapvF0y7C1e7A0jWFImsRrrvVslzyZz0919NED/cjFOpVWx7c973V+2S/w==
   dependencies:
-    "@emmetio/abbreviation" "^2.2.2"
-    "@emmetio/css-abbreviation" "^2.1.4"
+    "@emmetio/abbreviation" "^2.3.1"
+    "@emmetio/css-abbreviation" "^2.1.6"
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -250,6 +282,11 @@ es-to-primitive@^1.2.1:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
+
+es6-promise@^3.1.2:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.3.1.tgz#a08cdde84ccdbf34d027a1451bc91d4bcd28a613"
+  integrity sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -346,6 +383,11 @@ graceful-fs@^4.1.2:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
+
+graceful-fs@^4.1.3:
+  version "4.2.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
+  integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
 has-bigints@^1.0.1:
   version "1.0.1"
@@ -545,6 +587,13 @@ lower-case@^2.0.2:
   dependencies:
     tslib "^2.0.3"
 
+magic-string@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.27.0.tgz#e4a3413b4bab6d98d2becffd48b4a257effdbbf3"
+  integrity sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.13"
+
 memorystream@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
@@ -574,6 +623,18 @@ minimatch@^3.0.4:
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimist@^1.2.0, minimist@^1.2.6:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
+mkdirp@^0.5.1:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
+  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
+  dependencies:
+    minimist "^1.2.6"
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -698,15 +759,15 @@ pify@^3.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
   integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
 
-prettier-plugin-svelte@~2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-svelte/-/prettier-plugin-svelte-2.4.0.tgz#482bb6003bf1d5bd7ff002261a42a32b87d42d00"
-  integrity sha512-JwJ9bOz4XHLQtiLnX4mTSSDUdhu12WH8sTwy/XTDCSyPlah6IcV7NWeYBZscPEcceu2YnW8Y9sJCP40Z2UH9GA==
+prettier-plugin-svelte@~2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-svelte/-/prettier-plugin-svelte-2.10.0.tgz#ce8f641f97cfe085fa093cb2beb13e64c5e7f9de"
+  integrity sha512-GXMY6t86thctyCvQq+jqElO+MKdB09BkL3hexyGP3Oi8XLKRFaJP1ud/xlWCZ9ZIa2BxHka32zhHfcuU+XsRQg==
 
-prettier@2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
-  integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
+prettier@2.8.6:
+  version "2.8.6"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.6.tgz#5c174b29befd507f14b83e3c19f83fdc0e974b71"
+  integrity sha512-mtuzdiBbHwPEgl7NxWlqOkithPyp4VN93V7VeHVWBF+ad3I5avc0RVDT4oImXQy9H/AqxA2NSQH8pSxHW6FYbQ==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -742,6 +803,13 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
+rimraf@^2.5.2:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz"
@@ -755,6 +823,16 @@ run-parallel@^1.1.9:
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
+
+sander@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/sander/-/sander-0.5.1.tgz#741e245e231f07cafb6fdf0f133adfa216a502ad"
+  integrity sha512-3lVqBir7WuKDHGrKRDn/1Ye3kwpXaDOMsiRP1wd6wpZW56gJhsbp5RqQpA6JG/P+pkXizygnr1dKR8vzWaVsfA==
+  dependencies:
+    es6-promise "^3.1.2"
+    graceful-fs "^4.1.3"
+    mkdirp "^0.5.1"
+    rimraf "^2.5.2"
 
 "semver@2 || 3 || 4 || 5", semver@^5.5.0:
   version "5.7.1"
@@ -787,15 +865,15 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
-source-map@^0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
-  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
-
-sourcemap-codec@^1.4.8:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
-  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
+sorcery@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/sorcery/-/sorcery-0.11.0.tgz#310c80ee993433854bb55bb9aa4003acd147fca8"
+  integrity sha512-J69LQ22xrQB1cIFJhPfgtLuI6BpWRiWu1Y3vSsIwK/eAScqJxd/+CJlUuHQRdX2C9NGFamq+KqNywGgaThwfHw==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.14"
+    buffer-crc32 "^0.2.5"
+    minimist "^1.2.0"
+    sander "^0.5.0"
 
 spdx-correct@^3.0.0:
   version "3.1.1"
@@ -872,51 +950,53 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-svelte-language-server@^0.14.9:
-  version "0.14.9"
-  resolved "https://registry.yarnpkg.com/svelte-language-server/-/svelte-language-server-0.14.9.tgz#5097485840ecc669e1818c918982cebe5319c61d"
-  integrity sha512-mkMsAnGEO/wMsYfRdEKWKY9Hv/FwuCtB5RiJPcUcngHrVq8V+6zYGiZsmDTS4CArpfzhEuPcUNo1UM+E94Pslw==
+svelte-language-server@*:
+  version "0.15.9"
+  resolved "https://registry.yarnpkg.com/svelte-language-server/-/svelte-language-server-0.15.9.tgz#07a4cc66ce53aaac60d5ad310e3f10ce015ad733"
+  integrity sha512-MmXMYRvFvx0n2fVfYPOySAtbH5rVPt/8SF+Lx9SBH6jQXUA6QTGUd3tyYGV0dEZ63pEr+I9tBAHIoMT6Pc7OBA==
   dependencies:
+    "@jridgewell/trace-mapping" "^0.3.17"
+    "@vscode/emmet-helper" "^2.8.4"
     chokidar "^3.4.1"
     estree-walker "^2.0.1"
     fast-glob "^3.2.7"
     lodash "^4.17.21"
-    prettier "2.3.2"
-    prettier-plugin-svelte "~2.4.0"
-    source-map "^0.7.3"
-    svelte "~3.38.2"
-    svelte-preprocess "~4.7.3"
-    svelte2tsx "~0.4.0"
+    prettier "2.8.6"
+    prettier-plugin-svelte "~2.10.0"
+    svelte "^3.57.0"
+    svelte-preprocess "~5.0.3"
+    svelte2tsx "~0.6.8"
     typescript "*"
-    vscode-css-languageservice "5.0.0"
-    vscode-emmet-helper "2.1.2"
-    vscode-html-languageservice "4.0.0"
-    vscode-languageserver "7.1.0-next.4"
-    vscode-languageserver-types "3.16.0"
-    vscode-uri "2.1.2"
+    vscode-css-languageservice "~6.2.0"
+    vscode-html-languageservice "~5.0.0"
+    vscode-languageserver "8.0.2"
+    vscode-languageserver-protocol "3.17.2"
+    vscode-languageserver-types "3.17.2"
+    vscode-uri "~3.0.0"
 
-svelte-preprocess@~4.7.3:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/svelte-preprocess/-/svelte-preprocess-4.7.4.tgz#e4d5208ab25c2aaaf19e837f7d7bbf7930e61d2b"
-  integrity sha512-mDAmaltQl6e5zU2VEtoWEf7eLTfuOTGr9zt+BpA3AGHo8MIhKiNSPE9OLTCTOMgj0vj/uL9QBbaNmpG4G1CgIA==
+svelte-preprocess@~5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/svelte-preprocess/-/svelte-preprocess-5.0.3.tgz#431d538d457d3a5ba470a5ae5754a5aeb76579c8"
+  integrity sha512-GrHF1rusdJVbOZOwgPWtpqmaexkydznKzy5qIC2FabgpFyKN57bjMUUUqPRfbBXK5igiEWn1uO/DXsa2vJ5VHA==
   dependencies:
-    "@types/pug" "^2.0.4"
-    "@types/sass" "^1.16.0"
-    detect-indent "^6.0.0"
+    "@types/pug" "^2.0.6"
+    detect-indent "^6.1.0"
+    magic-string "^0.27.0"
+    sorcery "^0.11.0"
     strip-indent "^3.0.0"
 
-svelte2tsx@~0.4.0:
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/svelte2tsx/-/svelte2tsx-0.4.6.tgz#3435064962c910c0a075b4a1c04e91eaf568f5e5"
-  integrity sha512-flljgh/MbJDijo6Z1HhCfyzdRgn1Nd7QTuuxk9Oq5CzyBXZl/NJYh4otZZwUHnx5poy8k7Oxr2CBE3IBh89tmQ==
+svelte2tsx@~0.6.8:
+  version "0.6.11"
+  resolved "https://registry.yarnpkg.com/svelte2tsx/-/svelte2tsx-0.6.11.tgz#f9ae52adc40d3b0dfbd79a5178dd0a9f885176ad"
+  integrity sha512-rRW/3V/6mcejYWmSqcHpmILOSPsOhLgkbKbrTOz82s2n8TywmIsqj2jYPsiL6HeGoUM/atiTD0YKguW4b7ECog==
   dependencies:
     dedent-js "^1.0.1"
     pascal-case "^3.1.1"
 
-svelte@~3.38.2:
-  version "3.38.3"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.38.3.tgz#e15a1da98ee4b10162a6c8cb4c80aa86b2b589ed"
-  integrity sha512-N7bBZJH0iF24wsalFZF+fVYMUOigaAUQMIcEKHO3jstK/iL8VmP9xE+P0/a76+FkNcWt+TDv2Gx1taUoUscrvw==
+svelte@^3.57.0:
+  version "3.58.0"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.58.0.tgz#d3e6f103efd6129e51c7d709225ad3b4c052b64e"
+  integrity sha512-brIBNNB76mXFmU/Kerm4wFnkskBbluBDCjx/8TcpYRb298Yh2dztS2kQ6bhtjMcvUhd5ynClfwpz5h2gnzdQ1A==
 
 to-regex-range@^5.0.1:
   version "5.0.1"
@@ -930,18 +1010,18 @@ tslib@^2.0.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
-typescript-svelte-plugin@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/typescript-svelte-plugin/-/typescript-svelte-plugin-0.2.4.tgz#ed575cfe6a73119cc3d884af58a143bbd980a8e0"
-  integrity sha512-p6X58SWVYXuAubFIYJ4Qfvj2HjO9S33VEDzy3K4WGdwlqc/yX5oGsLSPgKKuFLbQfAep1BfinGBpw3Es3UkH3g==
+typescript-svelte-plugin@*:
+  version "0.3.22"
+  resolved "https://registry.yarnpkg.com/typescript-svelte-plugin/-/typescript-svelte-plugin-0.3.22.tgz#30d1a1789573dee6d8936f95b67fb376954a15d0"
+  integrity sha512-HbBAoRlzyqsqBBuD9yOldAweFvXUA2GfVM/HPuTbnyAZTpLgjSV73oR9yg4661qZC27ug5vvDtZLvvBTBn4GVA==
   dependencies:
-    sourcemap-codec "^1.4.8"
-    svelte2tsx "~0.4.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
+    svelte2tsx "~0.6.8"
 
-typescript@*, typescript@^4.4.3:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
-  integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
+typescript@*:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
+  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"
@@ -961,95 +1041,93 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vscode-css-languageservice@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-css-languageservice/-/vscode-css-languageservice-5.0.0.tgz#04fd899e25407a2fccd8f59a5896e2f020269bda"
-  integrity sha512-DTMa8QbVmujFPvD3NxoC5jjIXCyCG+cvn3hNzwQRhvhsk8LblNymBZBwzfcDdgEtqsi4O/2AB5HnMIRzxhzEzg==
+vscode-css-languageservice@~6.2.0:
+  version "6.2.5"
+  resolved "https://registry.yarnpkg.com/vscode-css-languageservice/-/vscode-css-languageservice-6.2.5.tgz#bcea53dac7b61c1ff483668a7403042779ab27b0"
+  integrity sha512-/1oyBZK3jfx6A0cA46FCUpy6OlqEsMT47LUIldCIP1YMKRYezJ9No+aNj9IM0AqhRZ92DxZ1DmU5lJ+biuiacA==
   dependencies:
-    vscode-languageserver-textdocument "^1.0.1"
-    vscode-languageserver-types "^3.16.0"
-    vscode-nls "^5.0.0"
-    vscode-uri "^2.1.2"
+    "@vscode/l10n" "^0.0.13"
+    vscode-languageserver-textdocument "^1.0.8"
+    vscode-languageserver-types "^3.17.3"
+    vscode-uri "^3.0.7"
 
-vscode-emmet-helper@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/vscode-emmet-helper/-/vscode-emmet-helper-2.1.2.tgz#2978060ebb736a7e0f6e6f1d649bd026880528c3"
-  integrity sha512-Fy6UNawSgxE3Kuqi54vSXohf03iOIrp1A74ReAgzvGP9Yt7fUAvkqF6No2WAc34/w0oWAHAeqoBNqmKKWh6U5w==
+vscode-html-languageservice@~5.0.0:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/vscode-html-languageservice/-/vscode-html-languageservice-5.0.5.tgz#3c7c7fdcea8f93914dfd8762a40dbfbe770e2243"
+  integrity sha512-7788ZT+I7/UhFoI4+bzaAiGGZEW7X39kTeuytLtw6jJA6W7ez85bWKYoFDcwrPNmywj3n/IkU9Op9asaje44jg==
   dependencies:
-    emmet "^2.1.5"
-    jsonc-parser "^2.3.0"
-    vscode-languageserver-textdocument "^1.0.1"
-    vscode-languageserver-types "^3.15.1"
-    vscode-nls "^5.0.0"
-    vscode-uri "^2.1.2"
+    "@vscode/l10n" "^0.0.13"
+    vscode-languageserver-textdocument "^1.0.8"
+    vscode-languageserver-types "^3.17.3"
+    vscode-uri "^3.0.7"
 
-vscode-html-languageservice@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-html-languageservice/-/vscode-html-languageservice-4.0.0.tgz#a562cb1dfe7e40a9d1f50dbd8c4ec2d02f393f01"
-  integrity sha512-UmC+GS0IqBeZnOAmdtQvaDzoH1c5/un+b7qALUziu/Y4SOPXso5dF+YkJeTqsde6YU2pLm78RtMDzl9BParwbw==
+vscode-jsonrpc@8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz#f239ed2cd6004021b6550af9fd9d3e47eee3cac9"
+  integrity sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==
+
+vscode-jsonrpc@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz#cb9989c65e219e18533cc38e767611272d274c94"
+  integrity sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==
+
+vscode-languageserver-protocol@3.17.2:
+  version "3.17.2"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz#beaa46aea06ed061576586c5e11368a9afc1d378"
+  integrity sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==
   dependencies:
-    vscode-languageserver-textdocument "^1.0.1"
-    vscode-languageserver-types "^3.16.0"
-    vscode-nls "^5.0.0"
-    vscode-uri "^2.1.2"
+    vscode-jsonrpc "8.0.2"
+    vscode-languageserver-types "3.17.2"
 
-vscode-jsonrpc@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz"
-  integrity sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==
-
-vscode-jsonrpc@6.1.0-next.2:
-  version "6.1.0-next.2"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-6.1.0-next.2.tgz#b5b67028d551d486c4ac1ec139ffc29382b36a2e"
-  integrity sha512-nkiNDGI+Ytp7uj1lxHXddXCoEunhcry1D+KmVHBfUUgWT9jMF8ZJyH5KQObdF+OGAh7bXZxD/SV4uGwSCeHHWA==
-
-vscode-languageserver-protocol@3.17.0-next.5:
-  version "3.17.0-next.5"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.0-next.5.tgz#295ebd7c416d7224b57e4de43c4bfefcc8095f06"
-  integrity sha512-LFZ6WMB3iPezQAU9OnGoERzcIVKhcs0OLfD/NHcqSj3g1wgxuLUL5kSlZbbjFySQCmhzm6b0yb3hjTSeBtq1+w==
+vscode-languageserver-protocol@^3.17.3:
+  version "3.17.3"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz#6d0d54da093f0c0ee3060b81612cce0f11060d57"
+  integrity sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==
   dependencies:
-    vscode-jsonrpc "6.1.0-next.2"
-    vscode-languageserver-types "3.17.0-next.1"
-
-vscode-languageserver-protocol@^3.15.3:
-  version "3.16.0"
-  resolved "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz"
-  integrity sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==
-  dependencies:
-    vscode-jsonrpc "6.0.0"
-    vscode-languageserver-types "3.16.0"
+    vscode-jsonrpc "8.1.0"
+    vscode-languageserver-types "3.17.3"
 
 vscode-languageserver-textdocument@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz#178168e87efad6171b372add1dea34f53e5d330f"
   integrity sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA==
 
-vscode-languageserver-types@3.16.0, vscode-languageserver-types@^3.15.1, vscode-languageserver-types@^3.16.0:
+vscode-languageserver-textdocument@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz#9eae94509cbd945ea44bca8dcfe4bb0c15bb3ac0"
+  integrity sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q==
+
+vscode-languageserver-types@3.17.2:
+  version "3.17.2"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz#b2c2e7de405ad3d73a883e91989b850170ffc4f2"
+  integrity sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==
+
+vscode-languageserver-types@3.17.3, vscode-languageserver-types@^3.17.3:
+  version "3.17.3"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz#72d05e47b73be93acb84d6e311b5786390f13f64"
+  integrity sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA==
+
+vscode-languageserver-types@^3.15.1:
   version "3.16.0"
   resolved "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz"
   integrity sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==
 
-vscode-languageserver-types@3.17.0-next.1:
-  version "3.17.0-next.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.0-next.1.tgz#396348493ccf567f0c22538033ebf95da5c5e4e3"
-  integrity sha512-VGzh06oynbYa6JbTKUbxOEZN7CYEtWhN7DK5wfzUpeCJl8X8xZX39g2PVfpqXrIEduu7dcJgK007KgnX9tHNKA==
-
-vscode-languageserver@7.1.0-next.4:
-  version "7.1.0-next.4"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-7.1.0-next.4.tgz#e9503af9d028dfc3a89e210646c265a087f46b8c"
-  integrity sha512-/65lxR/CuLJoOdzTjOTYUPWS7k5qzaWese4PObnWc6jwLryUrSa7DslYfaRXigh5/xr1nlaUZCcJwkpgM0wFvw==
+vscode-languageserver@8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-8.0.2.tgz#cfe2f0996d9dfd40d3854e786b2821604dfec06d"
+  integrity sha512-bpEt2ggPxKzsAOZlXmCJ50bV7VrxwCS5BI4+egUmure/oI/t4OlFzi/YNtVvY24A2UDOZAgwFGgnZPwqSJubkA==
   dependencies:
-    vscode-languageserver-protocol "3.17.0-next.5"
+    vscode-languageserver-protocol "3.17.2"
 
-vscode-nls@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-5.0.0.tgz#99f0da0bd9ea7cda44e565a74c54b1f2bc257840"
-  integrity sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA==
-
-vscode-uri@2.1.2, vscode-uri@^2.1.2:
+vscode-uri@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-2.1.2.tgz#c8d40de93eb57af31f3c715dd650e2ca2c096f1c"
   integrity sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==
+
+vscode-uri@^3.0.7, vscode-uri@~3.0.0:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.7.tgz#6d19fef387ee6b46c479e5fb00870e15e58c1eb8"
+  integrity sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA==
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR updates the plugin to the latest changes from the upstream repo.

This should also resolve issues such as those flagged by https://github.com/coc-extensions/coc-svelte/pull/60.

Additionally, version pins were removed for `svelte-language-server`, `typescript`, and `typescript-svelte-plugin`. This will make it simpler for users to test out the latest versions of the above packages by updating the lock file.